### PR TITLE
Expose Args.opts through function get_option, which takes an opt_name…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,15 @@ impl Args {
         })
     }
 
+    /// Retreives an `Option<Opt>` for the `Opt` identified by `opt_name`
+    ///
+    /// # Failures
+    ///
+    /// Returns `None` if no `Opt` corresponds to `opt_name`.
+    pub fn get_option(&self, opt_name :&str) -> Option<Box<Opt>> {
+        self.opts.get(opt_name).map(|opt| opt.clone())
+    }
+
     // Private instance methods
     fn register_opt(&mut self, opt: Box<Opt>) {
         if !self.opt_names.contains(&opt.name()) {

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -32,8 +32,17 @@ pub trait Opt: Send {
     fn name(&self) -> String;
     fn parse(&self, matches: &Matches) -> Option<String>;
     fn register(&self, options: &mut Options);
+    fn box_clone(&self) -> Box<Opt>;
 }
 
+impl Clone for Box<Opt>
+{
+    fn clone(&self) -> Box<Opt> {
+        self.box_clone()
+    }
+}
+
+#[derive(Clone)]
 struct Multi {
     short_name: String,
     long_name: String,
@@ -83,8 +92,13 @@ impl Opt for Multi {
             &self.desc,
             &self.hint);
     }
+
+    fn box_clone(&self) -> Box<Opt> {
+        Box::new((*self).clone())
+    }
 }
 
+#[derive(Clone)]
 struct Single {
     short_name: String,
     long_name: String,
@@ -156,6 +170,10 @@ impl Opt for Single {
             &self.hint,
             self.has_arg,
             self.occur);
+    }
+
+    fn box_clone(&self) -> Box<Opt> {
+        Box::new((*self).clone())
     }
 }
 


### PR DESCRIPTION
… and retrieves the associated option. Implement box cloning on Opt