### PR TITLE
Reexport getopts crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ accepts an optional log file name and responds to the help flag.
 
 ```rust
 extern crate args;
-extern crate getopts;
 
-use getopts::Occur;
 use std::process::exit;
 
 use args::{Args,ArgsError};
 use args::validations::{Order,OrderValidation};
+use args::getopts::Occur;
 
 const PROGRAM_DESC: &'static str = "Run this program";
 const PROGRAM_NAME: &'static str = "program";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,12 @@
 //!
 //! ```rust
 //! extern crate args;
-//! extern crate getopts;
 //!
-//! use getopts::Occur;
 //! use std::process::exit;
 //!
 //! use args::{Args,ArgsError};
 //! use args::validations::{Order,OrderValidation};
+//! use args::getopts::Occur;
 //!
 //! const PROGRAM_DESC: &'static str = "Run this program";
 //! const PROGRAM_NAME: &'static str = "program";
@@ -103,7 +102,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 #[macro_use] extern crate log;
-extern crate getopts;
+pub extern crate getopts;
 
 use getopts::{Fail,HasArg,Occur,Options};
 use std::collections::BTreeMap;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -15,7 +15,7 @@ pub fn new(short_name: &str,
         hint: &str,
         has_arg: HasArg,
         occur: Occur,
-        default: Option<String>) -> Box<Opt> {
+        default: Option<String>) -> Box<dyn Opt> {
     if has_arg == HasArg::Maybe { unsupported!("HasArg::Maybe"); }
 
     if occur != Occur::Multi {
@@ -32,12 +32,12 @@ pub trait Opt: Send {
     fn name(&self) -> String;
     fn parse(&self, matches: &Matches) -> Option<String>;
     fn register(&self, options: &mut Options);
-    fn box_clone(&self) -> Box<Opt>;
+    fn box_clone(&self) -> Box<dyn Opt>;
 }
 
-impl Clone for Box<Opt>
+impl Clone for Box<dyn Opt>
 {
-    fn clone(&self) -> Box<Opt> {
+    fn clone(&self) -> Box<dyn Opt> {
         self.box_clone()
     }
 }
@@ -93,7 +93,7 @@ impl Opt for Multi {
             &self.hint);
     }
 
-    fn box_clone(&self) -> Box<Opt> {
+    fn box_clone(&self) -> Box<dyn Opt> {
         Box::new((*self).clone())
     }
 }
@@ -172,18 +172,18 @@ impl Opt for Single {
             self.occur);
     }
 
-    fn box_clone(&self) -> Box<Opt> {
+    fn box_clone(&self) -> Box<dyn Opt> {
         Box::new((*self).clone())
     }
 }
 
-impl Display for Opt {
+impl Display for dyn Opt {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "option '-{} --{}'", self.flag(), self.name())
     }
 }
 
-impl Debug for Opt {
+impl Debug for dyn Opt {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         write!(f, "option '-{} --{}'", self.flag(), self.name())
     }

--- a/src/options/tst.rs
+++ b/src/options/tst.rs
@@ -2,7 +2,7 @@ use getopts::{HasArg,Occur};
 
 use options::{self,Opt};
 
-fn create(has_arg: HasArg, occur: Occur, default: Option<String>) -> Box<Opt> {
+fn create(has_arg: HasArg, occur: Occur, default: Option<String>) -> Box<dyn Opt> {
     options::new("o",
         "option",
         "Option",

--- a/src/traits/has_parsed_args.rs
+++ b/src/traits/has_parsed_args.rs
@@ -16,10 +16,10 @@ pub trait HasParsedArgs: Send {
     }
 
     /// Acts as a convenience method for calling the `Args` implementation.
-    fn optional_validated_value_of<T>(&self, opt_name: &str, validations: &[Box<Validation<T=T>>])
+    fn optional_validated_value_of<T>(&self, opt_name: &str, validations: &[Box<dyn Validation<T=T>>])
                                       -> Result<Option<T>, ArgsError> where T: FromStr {
         if self.has_value(opt_name) {
-            Ok(Some(try!(self.validated_value_of::<T>(opt_name, validations))))
+            Ok(Some(self.validated_value_of::<T>(opt_name, validations)?))
         } else {
             Ok(None)
         }
@@ -28,14 +28,14 @@ pub trait HasParsedArgs: Send {
     /// Acts as a convenience method for calling the `Args` implementation.
     fn optional_value_of<T: FromStr>(&self, opt_name: &str) -> Result<Option<T>, ArgsError> {
         if self.has_value(opt_name) {
-            Ok(Some(try!(self.value_of::<T>(opt_name))))
+            Ok(Some(self.value_of::<T>(opt_name)?))
         } else {
             Ok(None)
         }
     }
 
     /// Acts as a convenience method for calling the `Args` implementation.
-    fn validated_value_of<T>(&self, opt_name: &str, validations: &[Box<Validation<T=T>>])
+    fn validated_value_of<T>(&self, opt_name: &str, validations: &[Box<dyn Validation<T=T>>])
         -> Result<T, ArgsError> where T: FromStr {
         self.parsed_args().validated_value_of::<T>(opt_name, validations)
     }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -7,12 +7,11 @@
 //!
 //! ```rust
 //! extern crate args;
-//! extern crate getopts;
 //!
 //! use args::{Args,ArgsError};
 //! use args::traits::{HasArgs,HasParsedArgs};
 //! use args::validations::{Order,OrderValidation};
-//! use getopts::Occur;
+//! use args::getopts::Occur;
 //! use std::process::exit;
 //!
 //! const PROGRAM_DESC: &'static str = "Run this program";


### PR DESCRIPTION
Reexport getopts crate to avoid having an explicit dependency (also change documentation and readme). See #3 
It also fix two deprecations